### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,12 @@
 version: '3.8'
 
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.18.0.0/24
+
 services:
   flask01:
     image: app:0.3


### PR DESCRIPTION
Configurar uma rede evita o erro "docker-compose could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network".
Isso ocorre quando existe alguma VPN ativa.